### PR TITLE
Improved `uniqueValues`

### DIFF
--- a/cjs.d.ts
+++ b/cjs.d.ts
@@ -4,7 +4,30 @@ declare const _exports: {
     decodeBase64(encodedString: string): string;
     createObjectWithOrderedKeys(obj: any, startProperties?: string[], endProperties?: string[]): any;
     removeKeys(object: any, keys: string[]): any;
-    uniqueValues(array: any[], key: string, keys: any[]): any[];
+    uniqueValues(options?: {
+        /**
+         * Array of items or values to get unique values from
+         */
+        array: any[];
+        /**
+         * Key on item to get unique values for.
+         *
+         * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+         */
+        key?: string;
+        /**
+         * Array of which item keys to get unique items for.
+         *
+         * If this is not set this will return array with string values only.
+         *
+         * We will assume "array" contains object items.
+         *
+         * Requires "key" to be set
+         *
+         * Will return array with items containing keys.
+         */
+        keys?: any[];
+    }): any[];
     relativeDateFormat(options: {
         /**
          * Date object or date ISO string to format relative date from

--- a/es.d.ts
+++ b/es.d.ts
@@ -3,7 +3,30 @@ declare const _exports: {
     decodeBase64(encodedString: string): string;
     createObjectWithOrderedKeys(obj: any, startProperties?: string[], endProperties?: string[]): any;
     removeKeys(object: any, keys: string[]): any;
-    uniqueValues(array: any[], key: string, keys: any[]): any[];
+    uniqueValues(options?: {
+        /**
+         * Array of items or values to get unique values from
+         */
+        array: any[];
+        /**
+         * Key on item to get unique values for.
+         *
+         * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+         */
+        key?: string;
+        /**
+         * Array of which item keys to get unique items for.
+         *
+         * If this is not set this will return array with string values only.
+         *
+         * We will assume "array" contains object items.
+         *
+         * Requires "key" to be set
+         *
+         * Will return array with items containing keys.
+         */
+        keys?: any[];
+    }): any[];
     relativeDateFormat(options: {
         /**
          * Date object or date ISO string to format relative date from

--- a/lib/utilities.d.ts
+++ b/lib/utilities.d.ts
@@ -29,13 +29,51 @@ declare class Utilities {
      */
     static removeKeys(object: object, keys: string[]): any;
     /**
+     * UniqueValuesOption
+     * @typedef {Object} UniqueValuesOptions
+     * @property {Array} array Array of items or values to get unique values from
+     * @property {String} [key] Key on item to get unique values for.
+     *
+     * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+     * @property {Array} [keys] Array of which item keys to get unique items for.
+     *
+     * If this is not set this will return array with string values only.
+     *
+     * We will assume "array" contains object items.
+     *
+     * Requires "key" to be set
+     *
+     * Will return array with items containing keys.
+     */
+    /**
      * Get only unique key values from an array with items
-     * @param {Array} array Array of items to get unique values from
-     * @param {String} key Key on item to get unique values for. Will return array with string values only
-     * @param {Array} keys Array of which item keys to get unique items for. Will return array with items containing keys
+     * @param {UniqueValuesOptions} options UniqueValuesOptions
      * @returns {Array} Array of unique values
      */
-    static uniqueValues(array: any[], key: string, keys: any[]): any[];
+    static uniqueValues(options?: {
+        /**
+         * Array of items or values to get unique values from
+         */
+        array: any[];
+        /**
+         * Key on item to get unique values for.
+         *
+         * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+         */
+        key?: string;
+        /**
+         * Array of which item keys to get unique items for.
+         *
+         * If this is not set this will return array with string values only.
+         *
+         * We will assume "array" contains object items.
+         *
+         * Requires "key" to be set
+         *
+         * Will return array with items containing keys.
+         */
+        keys?: any[];
+    }): any[];
     /**
      * RelativeDateOptions
      * @typedef {Object} RelativeDateOptions

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -94,19 +94,37 @@ module.exports = class Utilities {
   }
 
   /**
+   * UniqueValuesOption
+   * @typedef {Object} UniqueValuesOptions
+   * @property {Array} array Array of items or values to get unique values from
+   * @property {String} [key] Key on item to get unique values for.
+   * 
+   * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+   * @property {Array} [keys] Array of which item keys to get unique items for.
+   * 
+   * If this is not set this will return array with string values only.
+   * 
+   * We will assume "array" contains object items.
+   * 
+   * Requires "key" to be set
+   * 
+   * Will return array with items containing keys.
+   */
+
+  /**
    * Get only unique key values from an array with items
-   * @param {Array} array Array of items to get unique values from
-   * @param {String} key Key on item to get unique values for. Will return array with string values only
-   * @param {Array} keys Array of which item keys to get unique items for. Will return array with items containing keys
+   * @param {UniqueValuesOptions} options UniqueValuesOptions
    * @returns {Array} Array of unique values
    */
-  static uniqueValues (array, key, keys) {
+  static uniqueValues (options = {}) {
+    const { array, key, keys } = options
     if (!array || !Array.isArray(array) || array.length === 0) return []
-    if (!key) return array
+    if (!key && !['string', 'boolean', 'number'].includes(typeof array[0])) return []
 
     const _array = []
     array.forEach(item => {
       if (!Array.isArray(keys)) {
+        if (!key && _array.includes(item)) return
         if (_array.includes(item[key])) return
       } else {
         const exists = _array.filter(arr => !keys.map(k => arr[k] === item[k]).includes(false))
@@ -114,7 +132,8 @@ module.exports = class Utilities {
       }
 
       if (!Array.isArray(keys)) {
-        _array.push(item[key])
+        if (!key) _array.push(item)
+        else _array.push(item[key])
       } else {
         const newItem = {}
         keys.forEach(k => {

--- a/lib/utilities_es.d.ts
+++ b/lib/utilities_es.d.ts
@@ -22,13 +22,51 @@ declare class Utilities {
      */
     static removeKeys(object: object, keys: string[]): any;
     /**
+     * UniqueValuesOption
+     * @typedef {Object} UniqueValuesOptions
+     * @property {Array} array Array of items or values to get unique values from
+     * @property {String} [key] Key on item to get unique values for.
+     *
+     * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+     * @property {Array} [keys] Array of which item keys to get unique items for.
+     *
+     * If this is not set this will return array with string values only.
+     *
+     * We will assume "array" contains object items.
+     *
+     * Requires "key" to be set
+     *
+     * Will return array with items containing keys.
+     */
+    /**
      * Get only unique key values from an array with items
-     * @param {Array} array Array of items to get unique values from
-     * @param {String} key Key on item to get unique values for. Will return array with string values only
-     * @param {Array} keys Array of which item keys to get unique items for. Will return array with items containing keys
+     * @param {UniqueValuesOptions} options UniqueValuesOptions
      * @returns {Array} Array of unique values
      */
-    static uniqueValues(array: any[], key: string, keys: any[]): any[];
+    static uniqueValues(options?: {
+        /**
+         * Array of items or values to get unique values from
+         */
+        array: any[];
+        /**
+         * Key on item to get unique values for.
+         *
+         * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+         */
+        key?: string;
+        /**
+         * Array of which item keys to get unique items for.
+         *
+         * If this is not set this will return array with string values only.
+         *
+         * We will assume "array" contains object items.
+         *
+         * Requires "key" to be set
+         *
+         * Will return array with items containing keys.
+         */
+        keys?: any[];
+    }): any[];
     /**
      * RelativeDateOptions
      * @typedef {Object} RelativeDateOptions

--- a/lib/utilities_es.js
+++ b/lib/utilities_es.js
@@ -79,19 +79,37 @@ module.exports = class Utilities {
   }
 
   /**
+   * UniqueValuesOption
+   * @typedef {Object} UniqueValuesOptions
+   * @property {Array} array Array of items or values to get unique values from
+   * @property {String} [key] Key on item to get unique values for.
+   * 
+   * If this is not set we will assume "array" is a flat array with values only and based on that will return unique values
+   * @property {Array} [keys] Array of which item keys to get unique items for.
+   * 
+   * If this is not set this will return array with string values only.
+   * 
+   * We will assume "array" contains object items.
+   * 
+   * Requires "key" to be set
+   * 
+   * Will return array with items containing keys.
+   */
+
+  /**
    * Get only unique key values from an array with items
-   * @param {Array} array Array of items to get unique values from
-   * @param {String} key Key on item to get unique values for. Will return array with string values only
-   * @param {Array} keys Array of which item keys to get unique items for. Will return array with items containing keys
+   * @param {UniqueValuesOptions} options UniqueValuesOptions
    * @returns {Array} Array of unique values
    */
-  static uniqueValues (array, key, keys) {
+  static uniqueValues (options = {}) {
+    const { array, key, keys } = options
     if (!array || !Array.isArray(array) || array.length === 0) return []
-    if (!key) return array
+    if (!key && !['string', 'boolean', 'number'].includes(typeof array[0])) return []
 
     const _array = []
     array.forEach(item => {
       if (!Array.isArray(keys)) {
+        if (!key && _array.includes(item)) return
         if (_array.includes(item[key])) return
       } else {
         const exists = _array.filter(arr => !keys.map(k => arr[k] === item[k]).includes(false))
@@ -99,7 +117,8 @@ module.exports = class Utilities {
       }
 
       if (!Array.isArray(keys)) {
-        _array.push(item[key])
+        if (!key) _array.push(item)
+        else _array.push(item[key])
       } else {
         const newItem = {}
         keys.forEach(k => {

--- a/tests/util/uniqueValues.test.js
+++ b/tests/util/uniqueValues.test.js
@@ -1,6 +1,11 @@
-const { uniqueValues } = require('../../cjs')
+const { uniqueValues } = require('../../lib/utilities')
+const { uniqueValues: uniqueValuesES } = require('../../lib/utilities_es')
+const funcs = {
+  cjs: uniqueValues,
+  es: uniqueValuesES
+}
 
-const array = [
+const itemArray = [
   {
     Id: 'BDK',
     SeksjonId: '',
@@ -39,45 +44,117 @@ const array = [
   }
 ]
 
-describe('uniqueValues', () => {
-  test('will return empty array when "array" not present', () => {
-    const result = uniqueValues()
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(0)
-  })
+const booleanArray = [
+  true,
+  false,
+  false,
+  true,
+  false,
+  true
+]
 
-  test('will return empty array when "array" given as an object', () => {
-    const result = uniqueValues({ prop: 'value' })
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(0)
-  })
+const numberArray = [
+  1,
+  1,
+  1,
+  2,
+  2,
+  2,
+  3,
+  4,
+  4,
+  4,
+  4
+]
 
-  test('will return the same array when "key" not present', () => {
-    const result = uniqueValues(array)
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(array.length)
-  })
+const stringArray = [
+  'One',
+  'One',
+  'One',
+  'Two',
+  'Two',
+  'Two',
+  'Two',
+  'Two',
+  'Two',
+  'Two',
+  'Two',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Three',
+  'Four'
+]
 
-  test('will return only unique values (one level)', () => {
-    const result = uniqueValues(array, 'SektorId')
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(2)
-    expect(typeof result[0]).toBe('string')
-    expect(typeof result[1]).toBe('string')
-  })
+// make sure uniqueValues works the same way in both "utilities" and "utilities_es"
+Object.getOwnPropertyNames(funcs).forEach(func => {
+  describe(`uniqueValues (${func})`, () => {
+    test('will return empty array when "array" not present', () => {
+      const result = funcs[func]()
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(0)
+    })
 
-  test('will return only unique values (items)', () => {
-    const result = uniqueValues(array, 'SektorId', ['SeksjonId'])
-    expect(Array.isArray(result)).toBe(true)
-    expect(result.length).toBe(3)
-    expect(typeof result[0]).toBe('object')
-    expect(typeof result[1]).toBe('object')
-    expect(typeof result[2]).toBe('object')
-    expect(Object.getOwnPropertyNames(result[0]).length).toBe(1)
-    expect(Object.getOwnPropertyNames(result[1]).length).toBe(1)
-    expect(Object.getOwnPropertyNames(result[2]).length).toBe(1)
-    expect(Object.getOwnPropertyNames(result[0])[0]).toBe('SeksjonId')
-    expect(Object.getOwnPropertyNames(result[1])[0]).toBe('SeksjonId')
-    expect(Object.getOwnPropertyNames(result[2])[0]).toBe('SeksjonId')
+    test('will return empty array when "array" given as an object', () => {
+      const result = funcs[func]({ array: { prop: 'value' } })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(0)
+    })
+
+    test('when "key" and "keys" not present and "array" has items - will return empty array', () => {
+      const result = funcs[func]({ array: itemArray })
+      expect(Array.isArray(result)).toBeTruthy()
+      expect(result.length).toBe(0)
+    })
+
+    test('when "key" and "keys" not present and "array" has booleans - will return flat array with unique values', () => {
+      const result = funcs[func]({ array: booleanArray })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(2)
+    })
+
+    test('when "key" and "keys" not present and "array" has numbers - will return flat array with unique values', () => {
+      const result = funcs[func]({ array: numberArray })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(4)
+    })
+
+    test('when "key" and "keys" not present and "array" has string - will return flat array with unique values', () => {
+      const result = funcs[func]({ array: stringArray })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(4)
+    })
+
+    test('will return only unique values (one level)', () => {
+      const result = funcs[func]({ array: itemArray, key: 'SektorId' })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(2)
+      expect(typeof result[0]).toBe('string')
+      expect(typeof result[1]).toBe('string')
+    })
+
+    test('will return only unique values (items)', () => {
+      const result = funcs[func]({ array: itemArray, key: 'SektorId', keys: ['SeksjonId'] })
+      expect(Array.isArray(result)).toBe(true)
+      expect(result.length).toBe(3)
+      expect(typeof result[0]).toBe('object')
+      expect(typeof result[1]).toBe('object')
+      expect(typeof result[2]).toBe('object')
+      expect(Object.getOwnPropertyNames(result[0]).length).toBe(1)
+      expect(Object.getOwnPropertyNames(result[1]).length).toBe(1)
+      expect(Object.getOwnPropertyNames(result[2]).length).toBe(1)
+      expect(Object.getOwnPropertyNames(result[0])[0]).toBe('SeksjonId')
+      expect(Object.getOwnPropertyNames(result[1])[0]).toBe('SeksjonId')
+      expect(Object.getOwnPropertyNames(result[2])[0]).toBe('SeksjonId')
+    })
   })
 })


### PR DESCRIPTION
## Improvements

- Made `key` optional. This allows to pass an array of **values** only and get a flat array in return containing only the unique values

## Breaking change

- Moved from three separate arguments (**array**, **key**, **keys**) to an **options** object (`{ array: [], key?: '', keys?: [] }`)